### PR TITLE
bugfix:采用hashcode方法;,原来是toString；增加功能：支持多消费者一致性。

### DIFF
--- a/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/loadbalance/ConsistentHashLoadBalance.java
+++ b/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/loadbalance/ConsistentHashLoadBalance.java
@@ -71,9 +71,11 @@ public class ConsistentHashLoadBalance extends AbstractLoadBalance {
             for (int i = 0; i < index.length; i ++) {
                 argumentIndex[i] = Integer.parseInt(index[i]);
             }
+            
             for (Invoker<T> invoker : invokers) {
                 for (int i = 0; i < replicaNumber / 4; i++) {
-                    byte[] digest = md5(invoker.getUrl().toFullString() + i);
+                	url  = invoker.getUrl();
+                    byte[] digest = md5(url.getIp()+"."+url.getPort()+"."+ i);
                     for (int h = 0; h < 4; h++) {
                         long m = hash(digest, h);
                         virtualInvokers.put(m, invoker);
@@ -97,7 +99,7 @@ public class ConsistentHashLoadBalance extends AbstractLoadBalance {
             StringBuilder buf = new StringBuilder();
             for (int i : argumentIndex) {
                 if (i >= 0 && i < args.length) {
-                    buf.append(args[i]);
+                    buf.append(args[i].hashCode());
                 }
             }
             return buf.toString();


### PR DESCRIPTION
1：原来的代码是 实现toString 方法，而不是hashCode,跟文档描述的不一致。
2：在实现hash一致性算法中， 有timestamp，pid 这些每次运行都不一样的因素，导致【 多消费者，消费者重启后，和 provider重启】发生后，会影响hash一致性。

