### PR TITLE
解决maven编译失败问题

### DIFF
--- a/dubbo-container/dubbo-container-api/pom.xml
+++ b/dubbo-container/dubbo-container-api/pom.xml
@@ -44,6 +44,11 @@
                 </exclusion>
             </exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.mortbay.jetty</groupId>
+			<artifactId>jetty-util</artifactId>
+			<version>6.1.26</version>
+		</dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>

--- a/dubbo-remoting/dubbo-remoting-http/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-http/pom.xml
@@ -44,6 +44,11 @@
                 </exclusion>
             </exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.mortbay.jetty</groupId>
+			<artifactId>jetty-util</artifactId>
+			<version>6.1.26</version>
+		</dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>


### PR DESCRIPTION
修改dubbo-remoting-http pom.xml 和dubbo-container-api的pom.xml 增加jetty-util依赖。避免maven编译失败。