### PR TITLE
解决基于Dubbo Annotation注解情况下的延迟暴露无效的问题

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/AnnotationBean.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/AnnotationBean.java
@@ -199,7 +199,10 @@ public class AnnotationBean extends AbstractConfig implements DisposableBean, Be
             }
             serviceConfig.setRef(bean);
             serviceConfigs.add(serviceConfig);
-            serviceConfig.export();
+            // fix by luopeng 检测延迟暴露
+            if(!serviceConfig.isDelay()){
+                serviceConfig.export();
+            }
         }
         return bean;
     }

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/ServiceBean.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/ServiceBean.java
@@ -112,7 +112,7 @@ public class ServiceBean<T> extends ServiceConfig<T> implements InitializingBean
         }
     }
     
-    private boolean isDelay() {
+    protected boolean isDelay() {
         Integer delay = getDelay();
         ProviderConfig provider = getProvider();
         if (delay == null && provider != null) {


### PR DESCRIPTION
在基于Dubbo Annotation扫描配置的情况下，配置的provider服务提供者  delay="-1" 属性失效。

原因是在其它情况下（XML配置服务），做了延迟暴露判断，而在Annotation下没有做延迟暴露检测而直接暴露。
