### PR TITLE
解决一个容器发布多个provider时可能造成端口冲突。

### DIFF
--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/utils/NetUtils.java
@@ -74,7 +74,7 @@ public class NetUtils {
     
     public static int getAvailablePort(int port) {
     	if (port <= 0) {
-    		return getAvailablePort();
+    		port = getAvailablePort();
     	}
     	for(int i = port; i < MAX_PORT; i ++) {
     		ServerSocket ss = null;

--- a/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/ServiceConfig.java
@@ -341,7 +341,7 @@ public class ServiceConfig<T> extends AbstractServiceConfig {
         if (port == null || port <= 0) {
             port = getRandomPort(name);
             if (port == null || port < 0) {
-                port = NetUtils.getAvailablePort(defaultPort);
+                port = NetUtils.getAvailablePort(-1);
                 putRandomPort(name, port);
             }
             logger.warn("Use random available port(" + port + ") for protocol " + name);


### PR DESCRIPTION
如果需要在一个容器中发布多个provider，需要设置<dubbo:registry/>的port属性为-1