### PR TITLE
简化dubbo javaconfig 方式的开发

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/AbstractConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/AbstractConfig.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.dubbo.config;
 
+import java.beans.PropertyDescriptor;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -22,6 +23,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.PropertyValues;
 
 import com.alibaba.dubbo.common.Constants;
 import com.alibaba.dubbo.common.URL;

--- a/dubbo-demo/dubbo-demo-provider/src/main/java/com/alibaba/dubbo/demo/bid/BidServiceImpl.java
+++ b/dubbo-demo/dubbo-demo-provider/src/main/java/com/alibaba/dubbo/demo/bid/BidServiceImpl.java
@@ -18,6 +18,9 @@ package com.alibaba.dubbo.demo.bid;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.alibaba.dubbo.config.annotation.Service;
+
+
 public class BidServiceImpl implements BidService {
 
     public BidResponse bid(BidRequest request) {

--- a/dubbo-javaconfig/dubbo-javaconfig-annotation/pom.xml
+++ b/dubbo-javaconfig/dubbo-javaconfig-annotation/pom.xml
@@ -1,0 +1,12 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.alibaba</groupId>
+    <artifactId>dubbo-javaconfig</artifactId>
+   	<version>2.8.4</version>
+  </parent>
+  <artifactId>dubbo-javaconfig-annotation</artifactId>
+  <packaging>jar</packaging>
+  <name>${project.artifactId}</name>
+  <description>The dubbo javaconfig annotation module of dubbo project</description>
+</project>

--- a/dubbo-javaconfig/dubbo-javaconfig-annotation/src/main/java/com/alibaba/dubbo/javaconfig/annotation/EnableDubbo.java
+++ b/dubbo-javaconfig/dubbo-javaconfig-annotation/src/main/java/com/alibaba/dubbo/javaconfig/annotation/EnableDubbo.java
@@ -1,0 +1,22 @@
+package com.alibaba.dubbo.javaconfig.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ *  auto register dubbox service
+ * 
+ * @author louis.huang
+ * @export
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE })
+public @interface EnableDubbo {
+	
+   String value() default "";
+
+}

--- a/dubbo-javaconfig/dubbo-javaconfig-demo-api/pom.xml
+++ b/dubbo-javaconfig/dubbo-javaconfig-demo-api/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.alibaba</groupId>
+		<artifactId>dubbo-javaconfig</artifactId>
+		<version>2.8.4</version>
+	</parent>
+	<artifactId>dubbo-javaconfig-demo-api</artifactId>
+	<packaging>jar</packaging>
+  	<name>${project.artifactId}</name>
+  	<description>The dubbo javaconfig  demo api module of dubbo project</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.alibaba</groupId>
+			<artifactId>dubbo-javaconfig-annotation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/dubbo-javaconfig/dubbo-javaconfig-demo-api/src/main/java/com/alibaba/demo/service/DemoService.java
+++ b/dubbo-javaconfig/dubbo-javaconfig-demo-api/src/main/java/com/alibaba/demo/service/DemoService.java
@@ -1,0 +1,14 @@
+package com.alibaba.demo.service;
+
+import com.alibaba.dubbo.javaconfig.annotation.EnableDubbo;
+
+@EnableDubbo
+public interface DemoService {
+
+	long push(ValueObject value);
+
+	boolean remove(long id);
+
+	ValueObject get(long id);
+
+}

--- a/dubbo-javaconfig/dubbo-javaconfig-demo-api/src/main/java/com/alibaba/demo/service/ValueObject.java
+++ b/dubbo-javaconfig/dubbo-javaconfig-demo-api/src/main/java/com/alibaba/demo/service/ValueObject.java
@@ -1,0 +1,47 @@
+package com.alibaba.demo.service;
+
+public class ValueObject implements java.io.Serializable {
+
+	private static final long serialVersionUID = 1L;
+	private long id;
+	private String name;
+	private String[] values;
+	private byte[] bytes;
+
+	public ValueObject() {
+		super();
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String[] getValues() {
+		return values;
+	}
+
+	public void setValues(String[] values) {
+		this.values = values;
+	}
+
+	public byte[] getBytes() {
+		return bytes;
+	}
+
+	public void setBytes(byte[] bytes) {
+		this.bytes = bytes;
+	}
+
+}

--- a/dubbo-javaconfig/dubbo-javaconfig-demo-consumer/pom.xml
+++ b/dubbo-javaconfig/dubbo-javaconfig-demo-consumer/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.alibaba</groupId>
+        <artifactId>dubbo-javaconfig</artifactId>
+        <version>2.8.4</version>
+    </parent>
+    <artifactId>dubbo-javaconfig-demo-consumer</artifactId>
+    <packaging>jar</packaging>
+    <name>${project.artifactId}</name>
+    <description>The dubbo javaconfig demo consumer module of dubbo project</description>
+    
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo-javaconfig-demo-api</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo-javaconfig-spring</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/dubbo-javaconfig/dubbo-javaconfig-demo-consumer/src/main/java/com/alibaba/demo/service/consumer/BussnessService.java
+++ b/dubbo-javaconfig/dubbo-javaconfig-demo-consumer/src/main/java/com/alibaba/demo/service/consumer/BussnessService.java
@@ -1,0 +1,39 @@
+package com.alibaba.demo.service.consumer;
+
+
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.alibaba.demo.service.DemoService;
+import com.alibaba.demo.service.ValueObject;
+
+//@Component
+public class BussnessService implements InitializingBean {
+	
+	@Autowired
+	private DemoService aneService;
+	@Autowired
+	private TestService testService;
+	
+	
+	public void start(){
+		 for( int i = 1 ; i < 100 ; i++) {
+			 ValueObject value = new ValueObject();
+			 value.setId(i);
+			 long l =   aneService.push(value);
+			 System.out.println(l);
+		 }
+		 
+		 testService.say();
+		
+	}
+
+
+	public void afterPropertiesSet() throws Exception {
+		this.start();
+		
+	}
+
+}

--- a/dubbo-javaconfig/dubbo-javaconfig-demo-consumer/src/main/java/com/alibaba/demo/service/consumer/TestService.java
+++ b/dubbo-javaconfig/dubbo-javaconfig-demo-consumer/src/main/java/com/alibaba/demo/service/consumer/TestService.java
@@ -1,0 +1,9 @@
+package com.alibaba.demo.service.consumer;
+
+public class TestService {
+	
+	public void say(){
+		System.out.println("say hello");
+	}
+
+}

--- a/dubbo-javaconfig/dubbo-javaconfig-demo-consumer/src/main/java/dubbo/spring/javaconfig/DubboxConfig.java
+++ b/dubbo-javaconfig/dubbo-javaconfig-demo-consumer/src/main/java/dubbo/spring/javaconfig/DubboxConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2006-2014 handu.com.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dubbo.spring.javaconfig;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.alibaba.demo.service.consumer.BussnessService;
+import com.alibaba.demo.service.consumer.TestService;
+
+/**
+ * @author Jinkai.Ma
+ */
+@Configuration
+public class DubboxConfig {
+
+    @Bean
+    public BussnessService aneBussnessService() {
+        return new BussnessService();
+    }
+
+    
+    @Bean
+    public TestService testService(){
+    	return new TestService();
+    }
+}

--- a/dubbo-javaconfig/dubbo-javaconfig-demo-consumer/src/main/java/dubbo/spring/javaconfig/DubboxConsumerConfig.java
+++ b/dubbo-javaconfig/dubbo-javaconfig-demo-consumer/src/main/java/dubbo/spring/javaconfig/DubboxConsumerConfig.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2006-2014 handu.com.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dubbo.spring.javaconfig;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.alibaba.dubbo.config.ApplicationConfig;
+import com.alibaba.dubbo.config.RegistryConfig;
+import com.alibaba.dubbo.javaconfig.spring.DubboConsumerFactory;
+import com.alibaba.dubbo.javaconfig.spring.DubboProviderFactory;
+
+/**
+ * @author Jinkai.Ma
+ */
+@Configuration
+public class DubboxConsumerConfig {
+
+    public static final String APPLICATION_NAME = "javaconfig-consumer-app";
+
+    public static final String REGISTRY_ADDRESS = "redis://127.0.0.1:6379";
+
+    public static final String ANNOTATION_PACKAGE = "com.alibaba.demo.service";
+
+    @Bean
+    public ApplicationConfig applicationConfig() {
+        ApplicationConfig applicationConfig = new ApplicationConfig();
+        applicationConfig.setName(APPLICATION_NAME);
+        return applicationConfig;
+    }
+
+    @Bean
+    public RegistryConfig registryConfig() {
+        RegistryConfig registryConfig = new RegistryConfig();
+        registryConfig.setAddress(REGISTRY_ADDRESS);
+        return registryConfig;
+    }
+
+//    @Bean
+//    public DubboxAnnotationBean dubboxAnnotationBean() {
+//    	DubboxAnnotationBean annotationBean = new DubboxAnnotationBean();
+//        annotationBean.setPackage(ANNOTATION_PACKAGE);
+//        return annotationBean;
+//    }
+    
+//    @Bean
+//    public ConsumerProxyFactoryBean consumerProxyFactoryBean(){
+//    	ConsumerProxyFactoryBean factoryBean = new ConsumerProxyFactoryBean();
+//    	factoryBean.setProxyInterface(AneService.class);
+//    	return factoryBean;
+//    }
+    
+    @Bean
+    public DubboConsumerFactory consumerFactory(){
+    	DubboConsumerFactory factory = new DubboConsumerFactory();
+    	factory.setPackage(ANNOTATION_PACKAGE);
+    	return factory;
+    }
+    
+    @Bean
+    public DubboProviderFactory providerFactory(){
+    	DubboProviderFactory factory = new DubboProviderFactory();
+    	factory.setPackage(ANNOTATION_PACKAGE);
+    	return factory;
+    }
+}

--- a/dubbo-javaconfig/dubbo-javaconfig-demo-consumer/src/main/resources/log4j.xml
+++ b/dubbo-javaconfig/dubbo-javaconfig-demo-consumer/src/main/resources/log4j.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ - Copyright 1999-2011 Alibaba Group.
+ -  
+ - Licensed under the Apache License, Version 2.0 (the "License");
+ - you may not use this file except in compliance with the License.
+ - You may obtain a copy of the License at
+ -  
+ -      http://www.apache.org/licenses/LICENSE-2.0
+ -  
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+	<appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+		<layout class="org.apache.log4j.PatternLayout">
+			<param name="ConversionPattern" value="[%d{dd/MM/yy hh:mm:ss:sss z}] %t %5p %c{2}: %m%n" />
+		</layout>
+	</appender>
+	<root>
+		<level value="INFO" />
+		<appender-ref ref="CONSOLE" />
+	</root>
+</log4j:configuration>

--- a/dubbo-javaconfig/dubbo-javaconfig-demo-consumer/src/test/java/main/MainRun.java
+++ b/dubbo-javaconfig/dubbo-javaconfig-demo-consumer/src/test/java/main/MainRun.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2006-2014 handu.com.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package main;
+
+/**
+ * @author Jinkai.Ma
+ */
+public class MainRun {
+    public static void main(String[] args) {
+        // add `javaconfig` to args
+        String[] customArgs = new String[]{"javaconfig"};
+        com.alibaba.dubbo.container.Main.main(customArgs);
+    }
+}

--- a/dubbo-javaconfig/dubbo-javaconfig-demo-provider/pom.xml
+++ b/dubbo-javaconfig/dubbo-javaconfig-demo-provider/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.alibaba</groupId>
+        <artifactId>dubbo-javaconfig</artifactId>
+        <version>2.8.4</version>
+    </parent>
+    <artifactId>dubbo-javaconfig-demo-provider</artifactId>
+    <packaging>jar</packaging>
+    <name>${project.artifactId}</name>
+    <description>The dubbo javaconfig demo provider module of dubbo project</description>
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo-javaconfig-demo-api</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo-javaconfig-spring</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/dubbo-javaconfig/dubbo-javaconfig-demo-provider/src/main/java/com/alibaba/demo/service/impl/DemoServiceImpl.java
+++ b/dubbo-javaconfig/dubbo-javaconfig-demo-provider/src/main/java/com/alibaba/demo/service/impl/DemoServiceImpl.java
@@ -1,0 +1,33 @@
+package com.alibaba.demo.service.impl;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.alibaba.demo.service.DemoService;
+import com.alibaba.demo.service.ValueObject;
+
+public class DemoServiceImpl implements DemoService {
+
+	private Map<Long, ValueObject> values = new ConcurrentHashMap<Long, ValueObject>();
+
+	public long push(ValueObject value) {
+		this.values.put(value.getId(), value);
+		return value.getId();
+	}
+
+	public boolean remove(long id) {
+		if (this.values.containsKey(id)) {
+			this.values.remove(id);
+			return true;
+		}
+		return false;
+	}
+
+	public ValueObject get(long id) {
+		if (this.values.containsKey(id)) {
+			return this.values.get(id);
+		}
+		return new ValueObject();
+	}
+
+}

--- a/dubbo-javaconfig/dubbo-javaconfig-demo-provider/src/main/java/dubbo/spring/javaconfig/DubboxConfig.java
+++ b/dubbo-javaconfig/dubbo-javaconfig-demo-provider/src/main/java/dubbo/spring/javaconfig/DubboxConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2006-2014 handu.com.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dubbo.spring.javaconfig;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.alibaba.demo.service.DemoService;
+import com.alibaba.demo.service.impl.DemoServiceImpl;
+
+/**
+ * @author Jinkai.Ma
+ */
+@Configuration
+public class DubboxConfig {
+
+    @Bean
+    public DemoService aneService() {
+        return new DemoServiceImpl();
+    }
+
+}

--- a/dubbo-javaconfig/dubbo-javaconfig-demo-provider/src/main/java/dubbo/spring/javaconfig/DubboxProviderConfig.java
+++ b/dubbo-javaconfig/dubbo-javaconfig-demo-provider/src/main/java/dubbo/spring/javaconfig/DubboxProviderConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2006-2014 handu.com.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dubbo.spring.javaconfig;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.alibaba.dubbo.config.ApplicationConfig;
+import com.alibaba.dubbo.config.RegistryConfig;
+import com.alibaba.dubbo.javaconfig.spring.DubboConsumerFactory;
+import com.alibaba.dubbo.javaconfig.spring.DubboProviderFactory;
+
+/**
+ * @author Jinkai.Ma
+ */
+@Configuration
+public class DubboxProviderConfig {
+
+    public static final String APPLICATION_NAME = "javaconfig-provider-app";
+
+    public static final String REGISTRY_ADDRESS = "redis://127.0.0.1:6379";
+
+    public static final String ANNOTATION_PACKAGE = "com.alibaba.demo.service";
+
+    @Bean
+    public ApplicationConfig applicationConfig() {
+        ApplicationConfig applicationConfig = new ApplicationConfig();
+        applicationConfig.setName(APPLICATION_NAME);
+        return applicationConfig;
+    }
+
+    @Bean
+    public RegistryConfig registryConfig() {
+        RegistryConfig registryConfig = new RegistryConfig();
+        registryConfig.setAddress(REGISTRY_ADDRESS);
+        return registryConfig;
+    }
+
+    @Bean
+    public DubboConsumerFactory consumerFactory(){
+    	DubboConsumerFactory factory = new DubboConsumerFactory();
+    	factory.setPackage(ANNOTATION_PACKAGE);
+    	return factory;
+    }
+    
+    @Bean
+    public DubboProviderFactory providerFactory(){
+    	DubboProviderFactory factory = new DubboProviderFactory();
+    	factory.setPackage(ANNOTATION_PACKAGE);
+    	return factory;
+    }
+    
+}

--- a/dubbo-javaconfig/dubbo-javaconfig-demo-provider/src/main/resources/log4j.xml
+++ b/dubbo-javaconfig/dubbo-javaconfig-demo-provider/src/main/resources/log4j.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ - Copyright 1999-2011 Alibaba Group.
+ -  
+ - Licensed under the Apache License, Version 2.0 (the "License");
+ - you may not use this file except in compliance with the License.
+ - You may obtain a copy of the License at
+ -  
+ -      http://www.apache.org/licenses/LICENSE-2.0
+ -  
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+	<appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+		<layout class="org.apache.log4j.PatternLayout">
+			<param name="ConversionPattern" value="[%d{dd/MM/yy hh:mm:ss:sss z}] %t %5p %c{2}: %m%n" />
+		</layout>
+	</appender>
+	<root>
+		<level value="INFO" />
+		<appender-ref ref="CONSOLE" />
+	</root>
+</log4j:configuration>

--- a/dubbo-javaconfig/dubbo-javaconfig-demo-provider/src/test/java/main/MainRun.java
+++ b/dubbo-javaconfig/dubbo-javaconfig-demo-provider/src/test/java/main/MainRun.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2006-2014 handu.com.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package main;
+
+/**
+ * @author Jinkai.Ma
+ */
+public class MainRun {
+    public static void main(String[] args) {
+        // add `javaconfig` to args
+        String[] customArgs = new String[]{"javaconfig"};
+        com.alibaba.dubbo.container.Main.main(customArgs);
+    }
+}

--- a/dubbo-javaconfig/dubbo-javaconfig-spring/pom.xml
+++ b/dubbo-javaconfig/dubbo-javaconfig-spring/pom.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.alibaba</groupId>
+    <artifactId>dubbo-javaconfig</artifactId>
+    <version>2.8.4</version>
+  </parent>
+  <artifactId>dubbo-javaconfig-spring</artifactId>
+  <packaging>jar</packaging>
+  <name>${project.artifactId}</name>
+  <description>The dubbo javaconfig  for spring module of dubbo project</description>
+  
+  <dependencies>
+  		<dependency>
+			<groupId>com.alibaba</groupId>
+			<artifactId>dubbo-javaconfig-annotation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.alibaba</groupId>
+			<artifactId>dubbo-config-spring</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/dubbo-javaconfig/dubbo-javaconfig-spring/src/main/java/com/alibaba/dubbo/javaconfig/spring/AbstractConfigFactory.java
+++ b/dubbo-javaconfig/dubbo-javaconfig-spring/src/main/java/com/alibaba/dubbo/javaconfig/spring/AbstractConfigFactory.java
@@ -1,0 +1,36 @@
+package com.alibaba.dubbo.javaconfig.spring;
+
+import com.alibaba.dubbo.common.Constants;
+import com.alibaba.dubbo.common.logger.Logger;
+import com.alibaba.dubbo.common.logger.LoggerFactory;
+
+public abstract class AbstractConfigFactory {
+ 
+	protected final Logger logger = LoggerFactory.getLogger(getClass());
+	private String annotationPackage;
+	private String[] annotationPackages;
+
+	public String getPackage() {
+		return annotationPackage;
+	}
+
+	public void setPackage(String annotationPackage) {
+		this.annotationPackage = annotationPackage;
+		this.annotationPackages = (annotationPackage == null || annotationPackage.length() == 0) ? null
+				: Constants.COMMA_SPLIT_PATTERN.split(annotationPackage);
+	}
+
+	protected boolean isMatchPackage(Class<?> beanClass) {
+		if (annotationPackages == null || annotationPackages.length == 0) {
+			return true;
+		}
+		String beanClassName = beanClass.getName();
+		for (String pkg : annotationPackages) {
+			if (beanClassName.startsWith(pkg)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/dubbo-javaconfig/dubbo-javaconfig-spring/src/main/java/com/alibaba/dubbo/javaconfig/spring/DubboConsumerFactory.java
+++ b/dubbo-javaconfig/dubbo-javaconfig-spring/src/main/java/com/alibaba/dubbo/javaconfig/spring/DubboConsumerFactory.java
@@ -1,0 +1,142 @@
+package com.alibaba.dubbo.javaconfig.spring;
+
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.PropertyValues;
+import org.springframework.beans.factory.BeanInitializationException;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.config.InstantiationAwareBeanPostProcessor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+import com.alibaba.dubbo.common.logger.Logger;
+import com.alibaba.dubbo.common.logger.LoggerFactory;
+import com.alibaba.dubbo.config.ReferenceConfig;
+import com.alibaba.dubbo.javaconfig.annotation.EnableDubbo;
+
+public class DubboConsumerFactory extends AbstractConfigFactory
+		implements BeanFactoryPostProcessor , ApplicationContextAware, InstantiationAwareBeanPostProcessor , DisposableBean {
+
+	private static final Logger logger = LoggerFactory.getLogger(Logger.class);
+	private ConfigurableListableBeanFactory beanFactory;
+	private ApplicationContext applicationContext;
+	private final ConcurrentMap<String, DubboxReferenceBean<?>> referenceConfigs = new ConcurrentHashMap<String, DubboxReferenceBean<?>>();
+	
+	public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+		this.beanFactory = beanFactory;
+	}
+
+	public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+		return bean;
+	}
+
+	public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+		return bean;
+	}
+
+	public Object postProcessBeforeInstantiation(Class<?> beanClass, String beanName) throws BeansException {
+		if (!isMatchPackage(beanClass)) {
+			return null;
+		}
+		
+		Set<Class<?>> proxies = getProxies(beanClass);
+		if (proxies != null && !proxies.isEmpty()) {
+			for (Class<?> proxy : proxies) {
+				if (!this.beanFactory.containsBean(proxy.getName())) {
+					this.beanFactory.registerSingleton(proxy.getName(),  refer(proxy));
+				}
+			}
+		}
+		return null;
+	}
+
+	public boolean postProcessAfterInstantiation(Object bean, String beanName) throws BeansException {
+		return true;
+	}
+
+	public PropertyValues postProcessPropertyValues(PropertyValues pvs, PropertyDescriptor[] pds, Object bean,
+			String beanName) throws BeansException {
+		return pvs;
+	}
+
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
+	}
+
+	private Set<Class<?>> getProxies(Class<?> beanClass) {
+
+		Set<Class<?>> classes = new HashSet<Class<?>>();
+
+		Method[] methods = beanClass.getMethods();
+		for (Method method : methods) {
+			String name = method.getName();
+			if (name.length() > 3 && name.startsWith("set") && method.getParameterTypes().length == 1
+					&& Modifier.isPublic(method.getModifiers()) && !Modifier.isStatic(method.getModifiers())) {
+				try {
+					if (method.getParameterTypes()[0].getAnnotation(EnableDubbo.class) != null
+							&& method.getAnnotation(Autowired.class) != null) {
+						classes.add(method.getParameterTypes()[0]);
+					}
+				} catch (Exception e) {
+					// modified by lishen
+					throw new BeanInitializationException("Failed to init remote service reference at method " + name
+							+ " in class " + beanClass.getClass().getName(), e);
+				}
+			}
+		}
+		Field[] fields = beanClass.getDeclaredFields();
+		for (Field field : fields) {
+			if (field.getType().getAnnotation(EnableDubbo.class) != null && field.getAnnotation(Autowired.class) != null) {
+				classes.add(field.getType());
+			}
+
+		}
+		return classes;
+	}
+	
+	private Object refer(Class<?> referenceClass) { // method.getParameterTypes()[0]
+		String interfaceName = referenceClass.getName();
+		String key = "/" + interfaceName + ":1.0";
+		DubboxReferenceBean<?> referenceConfig = referenceConfigs.get(key);
+		if (referenceConfig == null) {
+			referenceConfig = new DubboxReferenceBean<Object>();
+			referenceConfig.setInterface(referenceClass);
+
+			if (applicationContext != null) {
+				referenceConfig.setApplicationContext(applicationContext);
+				try {
+					referenceConfig.afterPropertiesSet();
+				} catch (RuntimeException e) {
+					throw (RuntimeException) e;
+				} catch (Exception e) {
+					throw new IllegalStateException(e.getMessage(), e);
+				}
+			}
+			referenceConfigs.putIfAbsent(key, referenceConfig);
+			referenceConfig = referenceConfigs.get(key);
+		}
+		return referenceConfig.get();
+	}
+
+	public void destroy() throws Exception {
+		for (ReferenceConfig<?> referenceConfig : referenceConfigs.values()) {
+			try {
+				referenceConfig.destroy();
+			} catch (Throwable e) {
+				logger.error(e.getMessage(), e);
+			}
+		}
+	}
+
+}

--- a/dubbo-javaconfig/dubbo-javaconfig-spring/src/main/java/com/alibaba/dubbo/javaconfig/spring/DubboProviderFactory.java
+++ b/dubbo-javaconfig/dubbo-javaconfig-spring/src/main/java/com/alibaba/dubbo/javaconfig/spring/DubboProviderFactory.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 1999-2012 Alibaba Group.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.javaconfig.spring;
+
+import java.util.Set;
+
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+import com.alibaba.dubbo.common.utils.ConcurrentHashSet;
+import com.alibaba.dubbo.config.ServiceConfig;
+import com.alibaba.dubbo.javaconfig.annotation.EnableDubbo;
+
+/**
+ * AnnotationBean
+ * 
+ * @author william.liangf
+ * @export
+ */
+public class DubboProviderFactory extends AbstractConfigFactory
+		implements DisposableBean, BeanPostProcessor, ApplicationContextAware {
+
+	private final Set<ServiceConfig<?>> serviceConfigs = new ConcurrentHashSet<ServiceConfig<?>>();
+	private ApplicationContext applicationContext;
+
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
+	}
+
+	public void destroy() throws Exception {
+		for (ServiceConfig<?> serviceConfig : serviceConfigs) {
+			try {
+				serviceConfig.unexport();
+			} catch (Throwable e) {
+				logger.error(e.getMessage(), e);
+			}
+		}
+	}
+
+	private Class<?> getDubboxInterface(Class<?> clazz) {
+		Class<?>[] interfaces = clazz.getInterfaces();
+		for (Class<?> class1 : interfaces) {
+			EnableDubbo dubbox = class1.getAnnotation(EnableDubbo.class);
+			if (dubbox != null) {
+				return class1;
+			}
+		}
+		return null;
+	}
+
+	public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+		if (!isMatchPackage(bean.getClass())) {
+			return bean;
+		}
+		Class<?> clazz = bean.getClass();
+		if (isProxyBean(bean)) {
+			clazz = AopUtils.getTargetClass(bean);
+		}
+		Class<?> provider = getDubboxInterface(clazz);
+		if (provider == null) {
+			return bean;
+		}
+
+		DubboxServiceBean<Object> serviceConfig = new DubboxServiceBean<Object>();
+		serviceConfig.setInterface(provider);
+		if (applicationContext != null) {
+			serviceConfig.setApplicationContext(applicationContext);
+			try {
+				serviceConfig.afterPropertiesSet();
+			} catch (RuntimeException e) {
+				throw (RuntimeException) e;
+			} catch (Exception e) {
+				e.printStackTrace();
+				throw new IllegalStateException(e.getMessage(), e);
+			}
+		}
+		serviceConfig.setRef(bean);
+		serviceConfigs.add(serviceConfig);
+		serviceConfig.export();
+		return bean;
+	}
+
+	public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+		return bean;
+	}
+
+	private boolean isProxyBean(Object bean) {
+		return AopUtils.isAopProxy(bean);
+	}
+}

--- a/dubbo-javaconfig/dubbo-javaconfig-spring/src/main/java/com/alibaba/dubbo/javaconfig/spring/DubboxReferenceBean.java
+++ b/dubbo-javaconfig/dubbo-javaconfig-spring/src/main/java/com/alibaba/dubbo/javaconfig/spring/DubboxReferenceBean.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 1999-2011 Alibaba Group.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.javaconfig.spring;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.BeanFactoryUtils;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+import com.alibaba.dubbo.config.ApplicationConfig;
+import com.alibaba.dubbo.config.ConsumerConfig;
+import com.alibaba.dubbo.config.ModuleConfig;
+import com.alibaba.dubbo.config.MonitorConfig;
+import com.alibaba.dubbo.config.ReferenceConfig;
+import com.alibaba.dubbo.config.RegistryConfig;
+import com.alibaba.dubbo.config.spring.extension.SpringExtensionFactory;
+import com.alibaba.dubbo.config.support.Parameter;
+
+/**
+ * ReferenceFactoryBean
+ * 
+ * @author william.liangf
+ * @export
+ */
+public class DubboxReferenceBean<T> extends ReferenceConfig<T> implements FactoryBean, ApplicationContextAware, InitializingBean, DisposableBean {
+
+	private static final long serialVersionUID = 213195494150089726L;
+	
+	private transient ApplicationContext applicationContext;
+
+	public DubboxReferenceBean() {
+        super();
+    }
+
+    public void setApplicationContext(ApplicationContext applicationContext) {
+		this.applicationContext = applicationContext;
+		SpringExtensionFactory.addApplicationContext(applicationContext);
+	}
+    
+    public Object getObject() throws Exception {
+        return get();
+    }
+
+    public Class<?> getObjectType() {
+        return getInterfaceClass();
+    }
+
+    @Parameter(excluded = true)
+    public boolean isSingleton() {
+        return true;
+    }
+
+    @SuppressWarnings({ "unchecked"})
+    public void afterPropertiesSet() throws Exception {
+        if (getConsumer() == null) {
+            Map<String, ConsumerConfig> consumerConfigMap = applicationContext == null ? null  : BeanFactoryUtils.beansOfTypeIncludingAncestors(applicationContext, ConsumerConfig.class, false, false);
+            if (consumerConfigMap != null && consumerConfigMap.size() > 0) {
+                ConsumerConfig consumerConfig = null;
+                for (ConsumerConfig config : consumerConfigMap.values()) {
+                    if (config.isDefault() == null || config.isDefault().booleanValue()) {
+                        if (consumerConfig != null) {
+                            throw new IllegalStateException("Duplicate consumer configs: " + consumerConfig + " and " + config);
+                        }
+                        consumerConfig = config;
+                    }
+                }
+                if (consumerConfig != null) {
+                    setConsumer(consumerConfig);
+                }
+            }
+        }
+        if (getApplication() == null
+                && (getConsumer() == null || getConsumer().getApplication() == null)) {
+            Map<String, ApplicationConfig> applicationConfigMap = applicationContext == null ? null : BeanFactoryUtils.beansOfTypeIncludingAncestors(applicationContext, ApplicationConfig.class, false, false);
+            if (applicationConfigMap != null && applicationConfigMap.size() > 0) {
+                ApplicationConfig applicationConfig = null;
+                for (ApplicationConfig config : applicationConfigMap.values()) {
+                    if (config.isDefault() == null || config.isDefault().booleanValue()) {
+                        if (applicationConfig != null) {
+                            throw new IllegalStateException("Duplicate application configs: " + applicationConfig + " and " + config);
+                        }
+                        applicationConfig = config;
+                    }
+                }
+                if (applicationConfig != null) {
+                    setApplication(applicationConfig);
+                }
+            }
+        }
+        if (getModule() == null
+                && (getConsumer() == null || getConsumer().getModule() == null)) {
+            Map<String, ModuleConfig> moduleConfigMap = applicationContext == null ? null : BeanFactoryUtils.beansOfTypeIncludingAncestors(applicationContext, ModuleConfig.class, false, false);
+            if (moduleConfigMap != null && moduleConfigMap.size() > 0) {
+                ModuleConfig moduleConfig = null;
+                for (ModuleConfig config : moduleConfigMap.values()) {
+                    if (config.isDefault() == null || config.isDefault().booleanValue()) {
+                        if (moduleConfig != null) {
+                            throw new IllegalStateException("Duplicate module configs: " + moduleConfig + " and " + config);
+                        }
+                        moduleConfig = config;
+                    }
+                }
+                if (moduleConfig != null) {
+                    setModule(moduleConfig);
+                }
+            }
+        }
+        if ((getRegistries() == null || getRegistries().size() == 0)
+                && (getConsumer() == null || getConsumer().getRegistries() == null || getConsumer().getRegistries().size() == 0)
+                && (getApplication() == null || getApplication().getRegistries() == null || getApplication().getRegistries().size() == 0)) {
+            Map<String, RegistryConfig> registryConfigMap = applicationContext == null ? null : BeanFactoryUtils.beansOfTypeIncludingAncestors(applicationContext, RegistryConfig.class, false, false);
+            if (registryConfigMap != null && registryConfigMap.size() > 0) {
+                List<RegistryConfig> registryConfigs = new ArrayList<RegistryConfig>();
+                for (RegistryConfig config : registryConfigMap.values()) {
+                    if (config.isDefault() == null || config.isDefault().booleanValue()) {
+                        registryConfigs.add(config);
+                    }
+                }
+                if (registryConfigs != null && registryConfigs.size() > 0) {
+                    super.setRegistries(registryConfigs);
+                }
+            }
+        }
+        if (getMonitor() == null
+                && (getConsumer() == null || getConsumer().getMonitor() == null)
+                && (getApplication() == null || getApplication().getMonitor() == null)) {
+            Map<String, MonitorConfig> monitorConfigMap = applicationContext == null ? null : BeanFactoryUtils.beansOfTypeIncludingAncestors(applicationContext, MonitorConfig.class, false, false);
+            if (monitorConfigMap != null && monitorConfigMap.size() > 0) {
+                MonitorConfig monitorConfig = null;
+                for (MonitorConfig config : monitorConfigMap.values()) {
+                    if (config.isDefault() == null || config.isDefault().booleanValue()) {
+                        if (monitorConfig != null) {
+                            throw new IllegalStateException("Duplicate monitor configs: " + monitorConfig + " and " + config);
+                        }
+                        monitorConfig = config;
+                    }
+                }
+                if (monitorConfig != null) {
+                    setMonitor(monitorConfig);
+                }
+            }
+        }
+        Boolean b = isInit();
+        if (b == null && getConsumer() != null) {
+            b = getConsumer().isInit();
+        }
+        if (b != null && b.booleanValue()) {
+            getObject();
+        }
+    }
+
+}

--- a/dubbo-javaconfig/dubbo-javaconfig-spring/src/main/java/com/alibaba/dubbo/javaconfig/spring/DubboxServiceBean.java
+++ b/dubbo-javaconfig/dubbo-javaconfig-spring/src/main/java/com/alibaba/dubbo/javaconfig/spring/DubboxServiceBean.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 1999-2011 Alibaba Group.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.javaconfig.spring;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.BeanFactoryUtils;
+import org.springframework.beans.factory.BeanNameAware;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.support.AbstractApplicationContext;
+
+import com.alibaba.dubbo.config.ApplicationConfig;
+import com.alibaba.dubbo.config.ModuleConfig;
+import com.alibaba.dubbo.config.MonitorConfig;
+import com.alibaba.dubbo.config.ProtocolConfig;
+import com.alibaba.dubbo.config.ProviderConfig;
+import com.alibaba.dubbo.config.RegistryConfig;
+import com.alibaba.dubbo.config.ServiceConfig;
+import com.alibaba.dubbo.config.spring.extension.SpringExtensionFactory;
+
+/**
+ * ServiceFactoryBean
+ * 
+ * @author william.liangf
+ * @export
+ */
+public class DubboxServiceBean<T> extends ServiceConfig<T> implements InitializingBean, DisposableBean, ApplicationContextAware, ApplicationListener, BeanNameAware {
+
+	private static final long serialVersionUID = 213195494150089726L;
+
+    private static transient ApplicationContext SPRING_CONTEXT;
+    
+	private transient ApplicationContext applicationContext;
+
+    private transient String beanName;
+
+    private transient boolean supportedApplicationListener;
+    
+	public DubboxServiceBean() {
+        super();
+    }
+
+    public static ApplicationContext getSpringContext() {
+	    return SPRING_CONTEXT;
+	}
+
+	public void setApplicationContext(ApplicationContext applicationContext) {
+		this.applicationContext = applicationContext;
+		SpringExtensionFactory.addApplicationContext(applicationContext);
+		if (applicationContext != null) {
+		    SPRING_CONTEXT = applicationContext;
+		    try {
+	            Method method = applicationContext.getClass().getMethod("addApplicationListener", new Class<?>[]{ApplicationListener.class}); // 兼容Spring2.0.1
+	            method.invoke(applicationContext, new Object[] {this});
+	            supportedApplicationListener = true;
+	        } catch (Throwable t) {
+                if (applicationContext instanceof AbstractApplicationContext) {
+    	            try {
+    	                Method method = AbstractApplicationContext.class.getDeclaredMethod("addListener", new Class<?>[]{ApplicationListener.class}); // 兼容Spring2.0.1
+                        if (! method.isAccessible()) {
+                            method.setAccessible(true);
+                        }
+    	                method.invoke(applicationContext, new Object[] {this});
+                        supportedApplicationListener = true;
+    	            } catch (Throwable t2) {
+    	            }
+	            }
+	        }
+		}
+	}
+
+    public void setBeanName(String name) {
+        this.beanName = name;
+    }
+
+    public void onApplicationEvent(ApplicationEvent event) {
+        if (ContextRefreshedEvent.class.getName().equals(event.getClass().getName())) {
+        	if (isDelay() && ! isExported() && ! isUnexported()) {
+                if (logger.isInfoEnabled()) {
+                    logger.info("The service ready on spring started. service: " + getInterface());
+                }
+                export();
+            }
+        }
+    }
+    
+    private boolean isDelay() {
+        Integer delay = getDelay();
+        ProviderConfig provider = getProvider();
+        if (delay == null && provider != null) {
+            delay = provider.getDelay();
+        }
+        return supportedApplicationListener && (delay == null || delay.intValue() == -1);
+    }
+
+    @SuppressWarnings({ "unchecked", "deprecation" })
+	public void afterPropertiesSet() throws Exception {
+        if (getProvider() == null) {
+            Map<String, ProviderConfig> providerConfigMap = applicationContext == null ? null  : BeanFactoryUtils.beansOfTypeIncludingAncestors(applicationContext, ProviderConfig.class, false, false);
+            if (providerConfigMap != null && providerConfigMap.size() > 0) {
+                Map<String, ProtocolConfig> protocolConfigMap = applicationContext == null ? null  : BeanFactoryUtils.beansOfTypeIncludingAncestors(applicationContext, ProtocolConfig.class, false, false);
+                if ((protocolConfigMap == null || protocolConfigMap.size() == 0)
+                        && providerConfigMap.size() > 1) { // 兼容旧版本
+                    List<ProviderConfig> providerConfigs = new ArrayList<ProviderConfig>();
+                    for (ProviderConfig config : providerConfigMap.values()) {
+                        if (config.isDefault() != null && config.isDefault().booleanValue()) {
+                            providerConfigs.add(config);
+                        }
+                    }
+                    if (providerConfigs.size() > 0) {
+                        setProviders(providerConfigs);
+                    }
+                } else {
+                    ProviderConfig providerConfig = null;
+                    for (ProviderConfig config : providerConfigMap.values()) {
+                        if (config.isDefault() == null || config.isDefault().booleanValue()) {
+                            if (providerConfig != null) {
+                                throw new IllegalStateException("Duplicate provider configs: " + providerConfig + " and " + config);
+                            }
+                            providerConfig = config;
+                        }
+                    }
+                    if (providerConfig != null) {
+                        setProvider(providerConfig);
+                    }
+                }
+            }
+        }
+        if (getApplication() == null
+                && (getProvider() == null || getProvider().getApplication() == null)) {
+            Map<String, ApplicationConfig> applicationConfigMap = applicationContext == null ? null : BeanFactoryUtils.beansOfTypeIncludingAncestors(applicationContext, ApplicationConfig.class, false, false);
+            if (applicationConfigMap != null && applicationConfigMap.size() > 0) {
+                ApplicationConfig applicationConfig = null;
+                for (ApplicationConfig config : applicationConfigMap.values()) {
+                    if (config.isDefault() == null || config.isDefault().booleanValue()) {
+                        if (applicationConfig != null) {
+                            throw new IllegalStateException("Duplicate application configs: " + applicationConfig + " and " + config);
+                        }
+                        applicationConfig = config;
+                    }
+                }
+                if (applicationConfig != null) {
+                    setApplication(applicationConfig);
+                }
+            }
+        }
+        if (getModule() == null
+                && (getProvider() == null || getProvider().getModule() == null)) {
+            Map<String, ModuleConfig> moduleConfigMap = applicationContext == null ? null : BeanFactoryUtils.beansOfTypeIncludingAncestors(applicationContext, ModuleConfig.class, false, false);
+            if (moduleConfigMap != null && moduleConfigMap.size() > 0) {
+                ModuleConfig moduleConfig = null;
+                for (ModuleConfig config : moduleConfigMap.values()) {
+                    if (config.isDefault() == null || config.isDefault().booleanValue()) {
+                        if (moduleConfig != null) {
+                            throw new IllegalStateException("Duplicate module configs: " + moduleConfig + " and " + config);
+                        }
+                        moduleConfig = config;
+                    }
+                }
+                if (moduleConfig != null) {
+                    setModule(moduleConfig);
+                }
+            }
+        }
+        if ((getRegistries() == null || getRegistries().size() == 0)
+                && (getProvider() == null || getProvider().getRegistries() == null || getProvider().getRegistries().size() == 0)
+                && (getApplication() == null || getApplication().getRegistries() == null || getApplication().getRegistries().size() == 0)) {
+            Map<String, RegistryConfig> registryConfigMap = applicationContext == null ? null : BeanFactoryUtils.beansOfTypeIncludingAncestors(applicationContext, RegistryConfig.class, false, false);
+            if (registryConfigMap != null && registryConfigMap.size() > 0) {
+                List<RegistryConfig> registryConfigs = new ArrayList<RegistryConfig>();
+                for (RegistryConfig config : registryConfigMap.values()) {
+                    if (config.isDefault() == null || config.isDefault().booleanValue()) {
+                        registryConfigs.add(config);
+                    }
+                }
+                if (registryConfigs != null && registryConfigs.size() > 0) {
+                    super.setRegistries(registryConfigs);
+                }
+            }
+        }
+        if (getMonitor() == null
+                && (getProvider() == null || getProvider().getMonitor() == null)
+                && (getApplication() == null || getApplication().getMonitor() == null)) {
+            Map<String, MonitorConfig> monitorConfigMap = applicationContext == null ? null : BeanFactoryUtils.beansOfTypeIncludingAncestors(applicationContext, MonitorConfig.class, false, false);
+            if (monitorConfigMap != null && monitorConfigMap.size() > 0) {
+                MonitorConfig monitorConfig = null;
+                for (MonitorConfig config : monitorConfigMap.values()) {
+                    if (config.isDefault() == null || config.isDefault().booleanValue()) {
+                        if (monitorConfig != null) {
+                            throw new IllegalStateException("Duplicate monitor configs: " + monitorConfig + " and " + config);
+                        }
+                        monitorConfig = config;
+                    }
+                }
+                if (monitorConfig != null) {
+                    setMonitor(monitorConfig);
+                }
+            }
+        }
+        if ((getProtocols() == null || getProtocols().size() == 0)
+                && (getProvider() == null || getProvider().getProtocols() == null || getProvider().getProtocols().size() == 0)) {
+            Map<String, ProtocolConfig> protocolConfigMap = applicationContext == null ? null  : BeanFactoryUtils.beansOfTypeIncludingAncestors(applicationContext, ProtocolConfig.class, false, false);
+            if (protocolConfigMap != null && protocolConfigMap.size() > 0) {
+                List<ProtocolConfig> protocolConfigs = new ArrayList<ProtocolConfig>();
+                for (ProtocolConfig config : protocolConfigMap.values()) {
+                    if (config.isDefault() == null || config.isDefault().booleanValue()) {
+                        protocolConfigs.add(config);
+                    }
+                }
+                if (protocolConfigs != null && protocolConfigs.size() > 0) {
+                    super.setProtocols(protocolConfigs);
+                }
+            }
+        }
+        if (getPath() == null || getPath().length() == 0) {
+            if (beanName != null && beanName.length() > 0 
+                    && getInterface() != null && getInterface().length() > 0
+                    && beanName.startsWith(getInterface())) {
+                setPath(beanName);
+            }
+        }
+        if (! isDelay()) {
+            export();
+        }
+    }
+
+    public void destroy() throws Exception {
+        unexport();
+    }
+
+    // added by lishen
+    @Override
+    protected Class getServiceClass(T ref) {
+        if (AopUtils.isAopProxy(ref)) {
+            return AopUtils.getTargetClass(ref);
+        }
+        return super.getServiceClass(ref);
+    }
+}

--- a/dubbo-javaconfig/pom.xml
+++ b/dubbo-javaconfig/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.alibaba</groupId>
+    <artifactId>dubbo-parent</artifactId>
+    <version>2.8.4</version>
+  </parent>
+  <artifactId>dubbo-javaconfig</artifactId>
+  <packaging>pom</packaging>
+  <name>${project.artifactId}</name>
+  <description>The javaconfig module of dubbo project</description>
+
+  <modules>
+  	<module>dubbo-javaconfig-annotation</module>
+  	<module>dubbo-javaconfig-spring</module>
+  	<module>dubbo-javaconfig-demo-api</module>
+  	<module>dubbo-javaconfig-demo-consumer</module>
+  	<module>dubbo-javaconfig-demo-provider</module>
+  </modules>
+  
+  <build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/dubbo-javaconfig/pom.xml
+++ b/dubbo-javaconfig/pom.xml
@@ -13,9 +13,6 @@
   <modules>
   	<module>dubbo-javaconfig-annotation</module>
   	<module>dubbo-javaconfig-spring</module>
-  	<module>dubbo-javaconfig-demo-api</module>
-  	<module>dubbo-javaconfig-demo-consumer</module>
-  	<module>dubbo-javaconfig-demo-provider</module>
   </modules>
   
   <build>

--- a/dubbo-rpc/dubbo-rpc-http/src/main/java/com/alibaba/dubbo/rpc/protocol/http/HttpProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-http/src/main/java/com/alibaba/dubbo/rpc/protocol/http/HttpProtocol.java
@@ -26,7 +26,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.remoting.RemoteAccessException;
-import org.springframework.remoting.httpinvoker.CommonsHttpInvokerRequestExecutor;
+import org.springframework.remoting.httpinvoker.HttpComponentsHttpInvokerRequestExecutor;
 import org.springframework.remoting.httpinvoker.HttpInvokerProxyFactoryBean;
 import org.springframework.remoting.httpinvoker.HttpInvokerServiceExporter;
 import org.springframework.remoting.httpinvoker.SimpleHttpInvokerRequestExecutor;
@@ -128,7 +128,7 @@ public class HttpProtocol extends AbstractProxyProtocol {
         	};
         	httpProxyFactoryBean.setHttpInvokerRequestExecutor(httpInvokerRequestExecutor);
         } else if ("commons".equals(client)) {
-        	CommonsHttpInvokerRequestExecutor httpInvokerRequestExecutor = new CommonsHttpInvokerRequestExecutor();
+        	HttpComponentsHttpInvokerRequestExecutor httpInvokerRequestExecutor = new HttpComponentsHttpInvokerRequestExecutor();
         	httpInvokerRequestExecutor.setReadTimeout(url.getParameter(Constants.CONNECT_TIMEOUT_KEY, Constants.DEFAULT_CONNECT_TIMEOUT));
         	httpProxyFactoryBean.setHttpInvokerRequestExecutor(httpInvokerRequestExecutor);
         } else if (client != null && client.length() > 0) {

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
 		<module>dubbo-registry</module>
 		<module>dubbo-monitor</module>
 		<module>dubbo-config</module>
+		<module>dubbo-javaconfig</module>
 		<module>dubbo</module>
 		<module>dubbo-simple</module>
 		<module>dubbo-admin</module>
@@ -84,7 +85,7 @@
 	</profiles>
 	<properties>
 		<!-- Common libs -->
-		<spring.bom.version>3.2.9.RELEASE</spring.bom.version>
+		<spring.bom.version>4.2.5.RELEASE</spring.bom.version>
 		<javassist_version>3.15.0-GA</javassist_version>
 		<netty_version>3.7.0.Final</netty_version>
 		<mina_version>1.1.7</mina_version>


### PR DESCRIPTION
在api 接口上加 @EnableDubbo 即可不再配置其他的信息让spring自动生成 provider 和 consumer
让开发dubbo 就像平常开发一致不需要在类里面加特定的 @Reference 和 @Service 