### PR TITLE
给rest filter添加PreMatching 注解。否则无法生效

### DIFF
--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/com/alibaba/dubbo/rpc/protocol/rest/RpcContextFilter.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/com/alibaba/dubbo/rpc/protocol/rest/RpcContextFilter.java
@@ -26,6 +26,7 @@ import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
 import java.io.IOException;
 import java.util.Map;
 
@@ -33,6 +34,7 @@ import java.util.Map;
  * @author lishen
  */
 @Priority(Integer.MIN_VALUE + 1)
+@PreMatching
 public class RpcContextFilter implements ContainerRequestFilter, ClientRequestFilter {
 
     private static final String DUBBO_ATTACHMENT_HEADER = "Dubbo-Attachments";

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/com/alibaba/dubbo/rpc/protocol/rest/support/LoggingFilter.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/com/alibaba/dubbo/rpc/protocol/rest/support/LoggingFilter.java
@@ -26,10 +26,7 @@ import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.client.ClientResponseContext;
 import javax.ws.rs.client.ClientResponseFilter;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.container.ContainerResponseContext;
-import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.*;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.ReaderInterceptor;
 import javax.ws.rs.ext.ReaderInterceptorContext;
@@ -48,6 +45,7 @@ import java.util.Map;
  * @author lishen
  */
 @Priority(Integer.MIN_VALUE)
+@PreMatching
 public class LoggingFilter implements ContainerRequestFilter, ClientRequestFilter, ContainerResponseFilter, ClientResponseFilter, WriterInterceptor, ReaderInterceptor {
 
     private static final Logger logger = LoggerFactory.getLogger(LoggingFilter.class);

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/com/alibaba/dubbo/rpc/protocol/rest/support/LoggingFilter.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/com/alibaba/dubbo/rpc/protocol/rest/support/LoggingFilter.java
@@ -20,7 +20,7 @@ import com.alibaba.dubbo.common.logger.LoggerFactory;
 import org.apache.commons.io.IOUtils;
 
 import javax.annotation.Priority;
-import javax.ws.rs.Priorities;
+
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;


### PR DESCRIPTION
rest filter都需要加 PreMatching 注解。 
否则 jboss resteasy 无法加载。