### PR TITLE
test(dubbo-config-spring): recover system property after test

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/ConfigTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/ConfigTest.java
@@ -860,7 +860,7 @@ public class ConfigTest {
 
             Assert.assertEquals(port, service.getExportedUrls().get(0).getPort());
         } finally {
-            System.setProperty("dubbo.protocol.dubbo.port", dubboPort);
+            System.setProperty("dubbo.protocol.dubbo.port", dubboPort == null ? "" : dubboPort);
             if (service != null) {
                 service.unexport();
             }

--- a/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/ConfigTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/ConfigTest.java
@@ -860,9 +860,7 @@ public class ConfigTest {
 
             Assert.assertEquals(port, service.getExportedUrls().get(0).getPort());
         } finally {
-            if (StringUtils.isNotEmpty(dubboPort)) {
-                System.setProperty("dubbo.protocol.dubbo.port", dubboPort);
-            }
+            System.setProperty("dubbo.protocol.dubbo.port", dubboPort);
             if (service != null) {
                 service.unexport();
             }


### PR DESCRIPTION
这里不应当判断原属性值是否为空，如果原属性为空，不会恢复原系统属性，会导致该属性影响后续其他test case，所以应当始终进行重置
