### PR TITLE
feat(travis-ci): add travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ jdk:
 before_script:
  - sudo service redis-server stop
  - redis-server --bind 127.0.0.1 --port 6379 --requirepass testpass --daemonize yes
- - "[ -f $HOME/.m2/zookeeper-3.4.8.tar.gz ] || wget http://www-eu.apache.org/dist/zookeeper/zookeeper-3.4.8/zookeeper-3.4.8.tar.gz -o $HOME/.m2/zookeeper-3.4.8.tar.gz"
- - tar zxf $HOME/.m2/zookeeper-3.4.8.tar.gz
+ - "[ -f /home/travis/.m2/zookeeper-3.4.8.tar.gz ] || wget http://www-eu.apache.org/dist/zookeeper/zookeeper-3.4.8/zookeeper-3.4.8.tar.gz -o /home/travis/.m2/zookeeper-3.4.8.tar.gz"
+ - tar zxf /home/travis/.m2/zookeeper-3.4.8.tar.gz
  - cp zookeeper-3.4.8/conf/zoo_sample.cfg zookeeper-3.4.8/conf/zoo.cfg
  - bash zookeeper-3.4.8/bin/zkServer.sh start
  - rm -rf $HOME/.m2/repository/com/alibaba/dubbo*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+# to stop redis
+sudo: true
 language: java
 # skip default install
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,39 @@
+sudo: false
 language: java
 # skip default install
 install: true
 # redis
 services:
-  - redis-server
+- redis-server
+
 cache:
   directories:
-   - $HOME/.m2
-
-jdk:
- - oraclejdk7
- - openjdk7
- - oraclejdk8
-# - openjdk6
+  - $HOME/.m2
 
 before_script:
- - sudo service redis-server stop
- - redis-server --bind 127.0.0.1 --port 6379 --requirepass testpass --daemonize yes
- - "[ -f $HOME/.m2/zookeeper-3.4.8.tar.gz ] || wget http://www-eu.apache.org/dist/zookeeper/zookeeper-3.4.8/zookeeper-3.4.8.tar.gz -O $HOME/.m2/zookeeper-3.4.8.tar.gz"
- - tar zxf $HOME/.m2/zookeeper-3.4.8.tar.gz
- - cp zookeeper-3.4.8/conf/zoo_sample.cfg zookeeper-3.4.8/conf/zoo.cfg
- - bash zookeeper-3.4.8/bin/zkServer.sh start
- - rm -rf $HOME/.m2/repository/com/alibaba/dubbo*
+- sudo service redis-server stop
+- redis-server --bind 127.0.0.1 --port 6379 --requirepass testpass --daemonize yes
+- "[ -f $HOME/.m2/zookeeper-3.4.8.tar.gz ] || wget http://www-eu.apache.org/dist/zookeeper/zookeeper-3.4.8/zookeeper-3.4.8.tar.gz -O $HOME/.m2/zookeeper-3.4.8.tar.gz"
+- tar zxf $HOME/.m2/zookeeper-3.4.8.tar.gz
+- cp zookeeper-3.4.8/conf/zoo_sample.cfg zookeeper-3.4.8/conf/zoo.cfg
+- bash zookeeper-3.4.8/bin/zkServer.sh start
+- rm -rf $HOME/.m2/repository/com/alibaba/dubbo*
 
 after_script:
- - bash zookeeper-3.4.8/bin/zkServer.sh stop
+- bash zookeeper-3.4.8/bin/zkServer.sh stop
 
 script:
 # - mvn -DskipTests=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -B -V clean install
 
- - mvn -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -B -V clean compile test
+- mvn -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -B -V clean compile test
 
 
 # travis
+matrix:
+  include:
+  - jdk: oraclejdk8
+  - jdk: oraclejdk7
+  - jdk: openjdk7
+  - jdk: openjdk6
+  allow_failures:
+  - jdk: openjdk6

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ jdk:
 before_script:
  - sudo service redis-server stop
  - redis-server --bind 127.0.0.1 --port 6379 --requirepass testpass --daemonize yes
- - "[ -f /home/travis/.m2/zookeeper-3.4.8.tar.gz ] || wget http://www-eu.apache.org/dist/zookeeper/zookeeper-3.4.8/zookeeper-3.4.8.tar.gz -o /home/travis/.m2/zookeeper-3.4.8.tar.gz"
- - tar zxf /home/travis/.m2/zookeeper-3.4.8.tar.gz
+ - "[ -f $HOME/.m2/zookeeper-3.4.8.tar.gz ] || wget http://www-eu.apache.org/dist/zookeeper/zookeeper-3.4.8/zookeeper-3.4.8.tar.gz -O $HOME/.m2/zookeeper-3.4.8.tar.gz"
+ - tar zxf $HOME/.m2/zookeeper-3.4.8.tar.gz
  - cp zookeeper-3.4.8/conf/zoo_sample.cfg zookeeper-3.4.8/conf/zoo.cfg
  - bash zookeeper-3.4.8/bin/zkServer.sh start
  - rm -rf $HOME/.m2/repository/com/alibaba/dubbo*

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,14 @@ cache:
 before_script:
 - sudo service redis-server stop
 - redis-server --bind 127.0.0.1 --port 6379 --requirepass testpass --daemonize yes
-- "[ -f $HOME/.m2/zookeeper-3.4.8.tar.gz ] || wget http://www-eu.apache.org/dist/zookeeper/zookeeper-3.4.8/zookeeper-3.4.8.tar.gz -O $HOME/.m2/zookeeper-3.4.8.tar.gz"
-- tar zxf $HOME/.m2/zookeeper-3.4.8.tar.gz
-- cp zookeeper-3.4.8/conf/zoo_sample.cfg zookeeper-3.4.8/conf/zoo.cfg
-- bash zookeeper-3.4.8/bin/zkServer.sh start
+#- "[ -f $HOME/.m2/zookeeper-3.4.8.tar.gz ] || wget http://www-eu.apache.org/dist/zookeeper/zookeeper-3.4.8/zookeeper-3.4.8.tar.gz -O $HOME/.m2/zookeeper-3.4.8.tar.gz"
+#- tar zxf $HOME/.m2/zookeeper-3.4.8.tar.gz
+#- cp zookeeper-3.4.8/conf/zoo_sample.cfg zookeeper-3.4.8/conf/zoo.cfg
+#- bash zookeeper-3.4.8/bin/zkServer.sh start
 - rm -rf $HOME/.m2/repository/com/alibaba/dubbo*
 
 after_script:
-- bash zookeeper-3.4.8/bin/zkServer.sh stop
+#- bash zookeeper-3.4.8/bin/zkServer.sh stop
 
 script:
 # - mvn -DskipTests=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -B -V clean install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: java
+# skip default install
+install: true
+# redis
+services:
+  - redis-server
+cache:
+  directories:
+   - $HOME/.m2
+
+jdk:
+ - oraclejdk7
+ - openjdk7
+ - oraclejdk8
+# - openjdk6
+
+before_script:
+ - sudo service redis-server stop
+ - redis-server --bind 127.0.0.1 --port 6379 --requirepass testpass --daemonize yes
+ - wget http://www-eu.apache.org/dist/zookeeper/zookeeper-3.4.8/zookeeper-3.4.8.tar.gz
+ - tar zxf zookeeper-3.4.8.tar.gz
+ - cp zookeeper-3.4.8/conf/zoo_sample.cfg zookeeper-3.4.8/conf/zoo.cfg
+ - bash zookeeper-3.4.8/bin/zkServer.sh start
+ - rm -rf $HOME/.m2/repository/com/alibaba/dubbo*
+
+after_script:
+ - bash zookeeper-3.4.8/bin/zkServer.sh stop
+
+script:
+# - mvn -DskipTests=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -B -V clean install
+
+ - mvn -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -B -V clean compile test
+
+
+# travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ jdk:
 before_script:
  - sudo service redis-server stop
  - redis-server --bind 127.0.0.1 --port 6379 --requirepass testpass --daemonize yes
- - wget http://www-eu.apache.org/dist/zookeeper/zookeeper-3.4.8/zookeeper-3.4.8.tar.gz
- - tar zxf zookeeper-3.4.8.tar.gz
+ - "[ -f $HOME/.m2/zookeeper-3.4.8.tar.gz ] || wget http://www-eu.apache.org/dist/zookeeper/zookeeper-3.4.8/zookeeper-3.4.8.tar.gz -o $HOME/.m2/zookeeper-3.4.8.tar.gz"
+ - tar zxf $HOME/.m2/zookeeper-3.4.8.tar.gz
  - cp zookeeper-3.4.8/conf/zoo_sample.cfg zookeeper-3.4.8/conf/zoo.cfg
  - bash zookeeper-3.4.8/bin/zkServer.sh start
  - rm -rf $HOME/.m2/repository/com/alibaba/dubbo*


### PR DESCRIPTION
集成Travis CI，这个pr只包含Travis CI配置，因为单元测试存在一些问题还不能构建成功。

集成Travis CI后有助于提高代码质量并且可以对每个pr自动运行单元测试。

我自己在集成过程中修复了若干个导致单元测试失败的问题，合并修复后的构建状态 [![Build Status](https://travis-ci.org/ian4hu/dubbox.svg?branch=feature%2Ftravis-ci-it)](https://travis-ci.org/ian4hu/dubbox) 直接点击查看构建状态
