### PR TITLE
Bugfix/test registry destroy fail

### DIFF
--- a/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/StickyTest.java
+++ b/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/StickyTest.java
@@ -71,7 +71,7 @@ public class StickyTest {
             +"&"+Constants.CLUSTER_STICKY_KEY+"=true"
             );
     
-    int runs = 1;
+    int runs = 2;
     @Test
     public void testStickyNoCheck() {
         int count = testSticky(null,false);

--- a/dubbo-registry/dubbo-registry-default/src/test/java/com/alibaba/dubbo/registry/dubbo/RegistryProtocolTest.java
+++ b/dubbo-registry/dubbo-registry-default/src/test/java/com/alibaba/dubbo/registry/dubbo/RegistryProtocolTest.java
@@ -16,6 +16,7 @@
 package com.alibaba.dubbo.registry.dubbo;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -144,12 +145,13 @@ public class RegistryProtocolTest {
      *测试destory registry ，exporter是否能够正常被destroy掉 
      */
     @Test
-    public void testDestoryRegistry(){
+    public void testDestoryRegistry() throws InterruptedException {
         URL newRegistryUrl = registryUrl.addParameter(Constants.EXPORT_KEY, serviceUrl);
         Invoker<RegistryProtocolTest> invoker = new MockInvoker<RegistryProtocolTest>(RegistryProtocolTest.class, newRegistryUrl);
         Exporter<?> exporter = protocol.export(invoker);
         destroyRegistryProtocol();
-        assertEquals(false, exporter.getInvoker().isAvailable());
+        Thread.sleep(1000);
+        assertFalse(exporter.getInvoker().isAvailable());
         
     }
     

--- a/dubbo-registry/dubbo-registry-default/src/test/java/com/alibaba/dubbo/registry/dubbo/RegistryProtocolTest.java
+++ b/dubbo-registry/dubbo-registry-default/src/test/java/com/alibaba/dubbo/registry/dubbo/RegistryProtocolTest.java
@@ -150,14 +150,14 @@ public class RegistryProtocolTest {
         Invoker<RegistryProtocolTest> invoker = new MockInvoker<RegistryProtocolTest>(RegistryProtocolTest.class, newRegistryUrl);
         Exporter<?> exporter = protocol.export(invoker);
         destroyRegistryProtocol();
-        Thread.sleep(1000);
         assertFalse(exporter.getInvoker().isAvailable());
         
     }
     
-    private void destroyRegistryProtocol(){
+    private void destroyRegistryProtocol() throws InterruptedException {
         Protocol registry = RegistryProtocol.getRegistryProtocol();
         registry.destroy();
+        Thread.sleep(1000);
     }
 
     private NotifyListener getListener(RegistryProtocol protocol) throws Exception {


### PR DESCRIPTION
在 travis ci上由于代码运行没有真机快，导致出现单元测试失败
