### PR TITLE
interfaces参数数组下标bug，javassist代理支持除声明接口外的接口调用支持

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/proxy/AbstractProxyFactory.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/proxy/AbstractProxyFactory.java
@@ -39,7 +39,7 @@ public abstract class AbstractProxyFactory implements ProxyFactory {
                 interfaces[0] = invoker.getInterface();
                 interfaces[1] = EchoService.class;
                 for (int i = 0; i < types.length; i ++) {
-                    interfaces[i + 1] = ReflectUtils.forName(types[i]);
+                    interfaces[i + 2] = ReflectUtils.forName(types[i]);
                 }
             }
         }


### PR DESCRIPTION
我们在做dubbox与CXF 的集成，在客户端支持异步时，需要调用客户端动态生成的代理类的 自定义接口org.apache.cxf.jaxrs.client.InvocationHandlerAware来获得客户端代理对象。目前dubbo生成的wrapper只能调用在服务接口上声明的接口方法。