### PR TITLE
throw right exception literals when generating adaptive class method signature

### DIFF
--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/extension/ExtensionLoader.java
@@ -931,7 +931,7 @@ public class ExtensionLoader<T> {
                     if (i > 0) {
                         codeBuidler.append(", ");
                     }
-                    codeBuidler.append(pts[i].getCanonicalName());
+                    codeBuidler.append(ets[i].getCanonicalName());
                 }
             }
             codeBuidler.append(" {");


### PR DESCRIPTION
Original code generates method signature exception literals using pts array which is parameter type array not exception type array.