### PR TITLE
Update start.sh

### DIFF
--- a/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.sh
+++ b/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.sh
@@ -14,7 +14,7 @@ if [ -z "$SERVER_NAME" ]; then
     SERVER_NAME=`hostname`
 fi
 
-PIDS=`ps -f | grep java | grep "$CONF_DIR" |awk '{print $2}'`
+PIDS=`ps -f | grep java | grep "$CONF_DIR" |grep -v grep |awk '{print $2}'`
 if [ -n "$PIDS" ]; then
     echo "ERROR: The $SERVER_NAME already started!"
     echo "PID: $PIDS"


### PR DESCRIPTION
修改linux 环境下，ps -f |grep java 出现  ”grep java“ 混淆java进程的问题。