### PR TITLE
解决实际环境中异步调用ServiceA，而ServiceA中同步调用ServiceB的时候，会出现异步属性多传递一次的问题，即Servic…

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/filter/AsyncFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/filter/AsyncFilter.java
@@ -1,0 +1,19 @@
+package com.alibaba.dubbo.rpc.filter;
+
+import com.alibaba.dubbo.common.Constants;
+import com.alibaba.dubbo.common.extension.Activate;
+import com.alibaba.dubbo.rpc.*;
+
+/**
+ * Author: 游锋锋
+ * Time: 2017-08-05 15:42
+ * Copyright (C) 2017 Xiamen Yaxon Networks CO.,LTD.
+ */
+@Activate(group = {Constants.PROVIDER})
+public class AsyncFilter implements Filter{
+    @Override
+    public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
+        RpcContext.getContext().getAttachments().remove(Constants.ASYNC_KEY);
+        return invoker.invoke(invocation);
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-api/src/main/resources/META-INF/dubbo/internal/com.alibaba.dubbo.rpc.Filter
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/resources/META-INF/dubbo/internal/com.alibaba.dubbo.rpc.Filter
@@ -12,3 +12,4 @@ executelimit=com.alibaba.dubbo.rpc.filter.ExecuteLimitFilter
 deprecated=com.alibaba.dubbo.rpc.filter.DeprecatedFilter
 compatible=com.alibaba.dubbo.rpc.filter.CompatibleFilter
 timeout=com.alibaba.dubbo.rpc.filter.TimeoutFilter
+asyncFilter=com.alibaba.dubbo.rpc.filter.AsyncFilter

--- a/yaxon-fix-bug.txt
+++ b/yaxon-fix-bug.txt
@@ -1,0 +1,6 @@
+--author:游锋锋
+--fix-bug:修复了dubbo中异步调用会多余传递一次异步属性的问题
+--fix-way:1、在dubbox\dubbo-rpc\dubbo-rpc-api\src\main\java\com\alibaba\dubbo\rpc\filter目录
+          下新增了AsyncFilter文件
+          2、并在同模块中的resource/META-INF.dubbo.internal的com.alibaba.dubbo.rpc.Filter
+          文件的末尾追加asyncFilter=com.alibaba.dubbo.rpc.filter.AsyncFilter


### PR DESCRIPTION
…eA中原本期望同步调用ServiceB，却变成异步调用ServiceB。这里通过不侵入原来代码，通过利用Filter在invoke的时候将attachment中的async的属性清空来解决