### PR TITLE
改正远程暴露时的注释文字错误

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/ServiceConfig.java
@@ -468,7 +468,7 @@ public class ServiceConfig<T> extends AbstractServiceConfig {
             if (!Constants.SCOPE_REMOTE.toString().equalsIgnoreCase(scope)) {
                 exportLocal(url);
             }
-            //如果配置不是local则暴露为远程服务.(配置为local，则表示只暴露远程服务)
+            //如果配置不是local则暴露为远程服务.(配置为local，则表示只暴露本地服务)
             if (! Constants.SCOPE_LOCAL.toString().equalsIgnoreCase(scope) ){
                 if (logger.isInfoEnabled()) {
                     logger.info("Export dubbo service " + interfaceClass.getName() + " to url " + url);


### PR DESCRIPTION
原文：
            //如果配置不是local则暴露为远程服务.(配置为local，则表示只暴露远程服务)
            if (! Constants.SCOPE_LOCAL.toString().equalsIgnoreCase(scope) ){
错误点：只暴露远程服务应改为只暴露本地服务
dubbo的服务暴露，scope配置为none则不暴露，配置为remote为远程暴露，配置为local则为本地暴露
相信当当的开发者应该知道上述的原理，而注释错误应该只是复制时忘了修改。
注释是代码的旁白，对于代码的阅读者有很大的引导作用，而服务暴露又是dubbo的必看之处。
所以希望改正